### PR TITLE
Add ddb_copy_info

### DIFF
--- a/plugins/ddb_copy_info/manifest.json
+++ b/plugins/ddb_copy_info/manifest.json
@@ -1,0 +1,21 @@
+{
+    source: {
+        type: "git",
+        url: "https://github.com/danpla/ddb_copy_info.git",
+        revision: "v1.0.0",
+    },
+    make: {
+        type: "make",
+        root: "/",
+        ENV: {
+            GTK2_CFLAGS: "$GTK216_CFLAGS",
+            GTK2_LIBS: "$GTK216_LIBS",
+            GTK3_CFLAGS: "$GTK310_CFLAGS",
+            GTK3_LIBS: "$GTK310_LIBS",
+        },
+        out: [
+            'ddb_copy_info_gtk2.so',
+            'ddb_copy_info_gtk3.so',
+        ]
+    }
+}


### PR DESCRIPTION
The plugin adds a menu entry to copy information about selected tracks to the clipboard using a custom format. This is the same as Copy name(s) function in foobar2000.